### PR TITLE
Fix V522 warning from PVS-Studio Static Analyzer

### DIFF
--- a/minibsdiff.c
+++ b/minibsdiff.c
@@ -140,16 +140,18 @@ diff(const char* oldf, const char* newf, const char* patchf)
 
   patchsz = bsdiff_patchsize_max(oldsz, newsz);
   patch = malloc(patchsz+1); /* Never malloc(0) */
-  res = bsdiff(old, oldsz, new, newsz, patch, patchsz);
-  if (res <= 0) barf("bsdiff() failed!");
-  patchsz = res;
+  if (patch) {
+      res = bsdiff(old, oldsz, new, newsz, patch, patchsz);
+      if (res <= 0) barf("bsdiff() failed!");
+      patchsz = res;
 
-#ifndef NDEBUG
-  printf("sizeof(delta('%s', '%s')) = %ld bytes\n", oldf, newf, patchsz);
-#endif /* NDEBUG */
+    #ifndef NDEBUG
+      printf("sizeof(delta('%s', '%s')) = %ld bytes\n", oldf, newf, patchsz);
+    #endif /* NDEBUG */
 
-  /* Write patch */
-  write_file(patchf, patch, patchsz);
+      /* Write patch */
+      write_file(patchf, patch, patchsz);
+  }
 
   free(old);
   free(new);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Dereferencing of the null pointer 'buf' might take place.
The potential null pointer is passed into 'write_file' function.
Inspect the second argument.